### PR TITLE
Allows to build plugin as independent package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ##---------------------------------------------------------------------------
 ## Author:      Jean-Eudes Onfray
-## Copyright:   
+## Copyright:
 ## License:     wxWidgets License
 ##---------------------------------------------------------------------------
 
@@ -47,12 +47,16 @@ IF(WIN32)
     ADD_DEFINITIONS(-D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE)
 ENDIF(WIN32)
 
+IF(UNIX AND NOT APPLE)
+  SET(PREFIX_PLUGINS /usr/lib/opencpn)
+  SET(PREFIX_DATA /usr/share)
+ENDIF(UNIX AND NOT APPLE)
 
-#SET(wxWidgets_USE_LIBS base core net xml html adv aui)
-#SET(BUILD_SHARED_LIBS TRUE)
-#SET( wxWidgets_USE_DEBUG OFF)
-#SET( wxWidgets_USE_UNICODE ON)
-#FIND_PACKAGE(wxWidgets REQUIRED)
+SET(wxWidgets_USE_LIBS base core net xml html adv aui)
+SET(BUILD_SHARED_LIBS TRUE)
+SET( wxWidgets_USE_DEBUG OFF)
+SET( wxWidgets_USE_UNICODE ON)
+FIND_PACKAGE(wxWidgets REQUIRED)
 
 INCLUDE(${wxWidgets_USE_FILE})
 

--- a/src/vdr_pi.h
+++ b/src/vdr_pi.h
@@ -45,7 +45,7 @@
 #include <wx/filepicker.h>
 #include <wx/file.h>
 #include <wx/aui/aui.h>
-#include "../../../include/ocpn_plugin.h"
+#include <opencpn/ocpn_plugin.h>
 
 #define VDR_TOOL_POSITION -1          // Request default positioning of toolbar tool
 


### PR DESCRIPTION
Hi,

I recently created a devel package for OpenCPN, so that plugins can be built separatly.
I patch yours, hope you'll enjoy it.

Please, see the [wiki page](https://en.opensuse.org/OpenCPN-build-plugins) and the [build page](https://build.opensuse.org/project/show/home:OrbitalRio:branches:Application:Geo:OpenCPN:head), where the OpenCPN-devel package is.
